### PR TITLE
Add an original, unaltered title for YT entries

### DIFF
--- a/views/youtube_feed.erb
+++ b/views/youtube_feed.erb
@@ -41,6 +41,7 @@
   <entry>
     <id>youtube:video:<%= video["id"] %><%= id_extra %><%= ":#{params[:cachebuster]}" if params[:cachebuster] %></id>
     <title><%= title.esc %></title>
+    <original_title><%= video["snippet"]["title"].to_line.esc %></original_title>
     <link href="https://www.youtube.com/watch?v=<%= video["id"] %>" />
     <updated><%= updated %></updated>
     <author><name><%= @username.esc %></name></author>


### PR DESCRIPTION
There are RSS readers that can let users to customize their feeds and how they are displayed.
This way if everyone wants to see/set original title, it's possible to use <original_title>.